### PR TITLE
Add RecordBuilder type

### DIFF
--- a/stuffed/rapid_test.go
+++ b/stuffed/rapid_test.go
@@ -108,3 +108,10 @@ func TestRecordBuilderWithRandomLists(t *testing.T) {
 		checkRecordBuilder(t, inputList)
 	})
 }
+
+func TestSortedRecordBuilderWithRandomLists(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		inputList := rapid.SliceOf(inputString).Draw(t, "inputList").([]string)
+		checkSortedRecordBuilder(t, inputList)
+	})
+}

--- a/stuffed/rapid_test.go
+++ b/stuffed/rapid_test.go
@@ -94,9 +94,17 @@ func TestEncodedStartsWithRandomLists(t *testing.T) {
 		checkEncodedStartsWith(t, inputList, prefix, expected)
 	})
 }
+
 func TestFindRecordsWithPrefixRandomLists(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		inputList, prefix, expected := prefixLists(t)
 		checkFindRecordsWithPrefix(t, inputList, prefix, expected)
+	})
+}
+
+func TestRecordBuilderWithRandomLists(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		inputList := rapid.SliceOf(inputString).Draw(t, "inputList").([]string)
+		checkRecordBuilder(t, inputList)
 	})
 }

--- a/stuffed/records.go
+++ b/stuffed/records.go
@@ -1,0 +1,41 @@
+package stuffed
+
+import (
+	"bytes"
+)
+
+// RecordBuilder makes it easier to build up the content of individual records,
+// which are then written into a buffer using the stuffed records encoding.  To
+// build up the content of an individual record, just use the RecordBuilder as a
+// bytes.Buffer.  Once a record is done, call FinishRecord.  Once you are done
+// with all records, call Encode to get the encoded representation of
+// everything.
+type RecordBuilder struct {
+	bytes.Buffer
+	start         int
+	recordIndices []index
+}
+
+type index struct {
+	start, end int
+}
+
+// FinishRecord indicates that you have finished constructing an individual
+// record.  We don't actually encode the record until you call Encode, when we
+// encode _all_ of the records that you add to the builder.
+func (rb *RecordBuilder) FinishRecord() {
+	end := rb.Len()
+	rb.recordIndices = append(rb.recordIndices, index{rb.start, end})
+	rb.start = end
+}
+
+// Encode encodes all of the records in this builder into an output buffer,
+// using the stuffed records encoding.
+func (rb *RecordBuilder) Encode(dest *bytes.Buffer) {
+	records := rb.Bytes()
+	for _, index := range rb.recordIndices {
+		record := records[index.start:index.end]
+		Encode(record, dest)
+		EncodeDelimiter(dest)
+	}
+}

--- a/stuffed/records_test.go
+++ b/stuffed/records_test.go
@@ -1,0 +1,43 @@
+package stuffed_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dcreager/stuffed-records-go/stuffed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func checkRecordBuilder(t require.TestingT, inputList []string) {
+	var builder stuffed.RecordBuilder
+	var encoded bytes.Buffer
+	for _, str := range inputList {
+		builder.WriteString(str)
+		builder.FinishRecord()
+	}
+	builder.Encode(&encoded)
+
+	var decoded bytes.Buffer
+	var scanner stuffed.Scanner
+	scanner.Reset(encoded.Bytes())
+	actual := []string{}
+	for scanner.Next() {
+		decoded.Reset()
+		err := scanner.Decode(&decoded)
+		require.NoError(t, err)
+		actual = append(actual, decoded.String())
+	}
+	assert.Equal(t, inputList, actual)
+}
+
+func TestRecordBuilder(t *testing.T) {
+	testCases := [][]string{
+		{},
+		{"hello", "there"},
+		{"what is\xfe\xfdgoing on"},
+	}
+	for i := range testCases {
+		checkRecordBuilder(t, testCases[i])
+	}
+}

--- a/stuffed/records_test.go
+++ b/stuffed/records_test.go
@@ -2,6 +2,7 @@ package stuffed_test
 
 import (
 	"bytes"
+	"sort"
 	"testing"
 
 	"github.com/dcreager/stuffed-records-go/stuffed"
@@ -39,5 +40,40 @@ func TestRecordBuilder(t *testing.T) {
 	}
 	for i := range testCases {
 		checkRecordBuilder(t, testCases[i])
+	}
+}
+
+func checkSortedRecordBuilder(t require.TestingT, inputList []string) {
+	var builder stuffed.RecordBuilder
+	var encoded bytes.Buffer
+	for _, str := range inputList {
+		builder.WriteString(str)
+		builder.FinishRecord()
+	}
+	builder.Sort()
+	builder.Encode(&encoded)
+
+	var decoded bytes.Buffer
+	var scanner stuffed.Scanner
+	scanner.Reset(encoded.Bytes())
+	actual := []string{}
+	for scanner.Next() {
+		decoded.Reset()
+		err := scanner.Decode(&decoded)
+		require.NoError(t, err)
+		actual = append(actual, decoded.String())
+	}
+	sort.Strings(inputList)
+	assert.Equal(t, inputList, actual)
+}
+
+func TestSortedRecordBuilder(t *testing.T) {
+	testCases := [][]string{
+		{},
+		{"2 hello", "1 there", "0 world"},
+		{"what is\xfe\xfdgoing on"},
+	}
+	for i := range testCases {
+		checkSortedRecordBuilder(t, testCases[i])
 	}
 }


### PR DESCRIPTION
This lets you build up individual records using the `bytes.Buffer` API, and then build up the stuffed records encoding of all of those records.