### PR TITLE
Keep track of offsets of encoded records

### DIFF
--- a/stuffed/records_test.go
+++ b/stuffed/records_test.go
@@ -32,21 +32,41 @@ func checkRecordBuilder(t require.TestingT, inputList []string) {
 	assert.Equal(t, inputList, actual)
 }
 
+func checkRecordBuilderOffsets(t require.TestingT, inputList []string, expectedOffsets []int) {
+	var builder stuffed.RecordBuilder
+	var encoded bytes.Buffer
+	for _, str := range inputList {
+		builder.WriteString(str)
+		builder.FinishRecord()
+	}
+	offsets := builder.EncodeWithOffsets(&encoded)
+	assert.Equal(t, expectedOffsets, offsets)
+}
+
 func TestRecordBuilder(t *testing.T) {
 	testCases := [][]string{
 		{},
 		{"hello", "there"},
 		{"what is\xfe\xfdgoing on"},
 	}
+	offsets := [][]int{
+		{},
+		{0, 8},
+		{0},
+	}
 	for i := range testCases {
 		checkRecordBuilder(t, testCases[i])
+		checkRecordBuilderOffsets(t, testCases[i], offsets[i])
 	}
 }
 
 func checkSortedRecordBuilder(t require.TestingT, inputList []string) {
+	copied := make([]string, len(inputList))
+	copy(copied, inputList)
+
 	var builder stuffed.RecordBuilder
 	var encoded bytes.Buffer
-	for _, str := range inputList {
+	for _, str := range copied {
 		builder.WriteString(str)
 		builder.FinishRecord()
 	}
@@ -63,8 +83,20 @@ func checkSortedRecordBuilder(t require.TestingT, inputList []string) {
 		require.NoError(t, err)
 		actual = append(actual, decoded.String())
 	}
-	sort.Strings(inputList)
-	assert.Equal(t, inputList, actual)
+	sort.Strings(copied)
+	assert.Equal(t, copied, actual)
+}
+
+func checkSortedRecordBuilderOffsets(t require.TestingT, inputList []string, expectedOffsets []int) {
+	var builder stuffed.RecordBuilder
+	var encoded bytes.Buffer
+	for _, str := range inputList {
+		builder.WriteString(str)
+		builder.FinishRecord()
+	}
+	builder.Sort()
+	offsets := builder.EncodeWithOffsets(&encoded)
+	assert.Equal(t, expectedOffsets, offsets)
 }
 
 func TestSortedRecordBuilder(t *testing.T) {
@@ -73,7 +105,13 @@ func TestSortedRecordBuilder(t *testing.T) {
 		{"2 hello", "1 there", "0 world"},
 		{"what is\xfe\xfdgoing on"},
 	}
+	offsets := [][]int{
+		{},
+		{20, 10, 0},
+		{0},
+	}
 	for i := range testCases {
 		checkSortedRecordBuilder(t, testCases[i])
+		checkSortedRecordBuilderOffsets(t, testCases[i], offsets[i])
 	}
 }

--- a/stuffed/records_test.go
+++ b/stuffed/records_test.go
@@ -41,6 +41,16 @@ func checkRecordBuilderOffsets(t require.TestingT, inputList []string, expectedO
 	}
 	offsets := builder.EncodeWithOffsets(&encoded)
 	assert.Equal(t, expectedOffsets, offsets)
+	for i := 0; i < encoded.Len(); i++ {
+		isValidOffset := false
+		for _, offset := range offsets {
+			if offset == i {
+				isValidOffset = true
+			}
+		}
+		actual := stuffed.IsStartOfRecord(encoded.Bytes(), i)
+		assert.Equal(t, isValidOffset, actual)
+	}
 }
 
 func TestRecordBuilder(t *testing.T) {
@@ -97,6 +107,16 @@ func checkSortedRecordBuilderOffsets(t require.TestingT, inputList []string, exp
 	builder.Sort()
 	offsets := builder.EncodeWithOffsets(&encoded)
 	assert.Equal(t, expectedOffsets, offsets)
+	for i := 0; i < encoded.Len(); i++ {
+		isValidOffset := false
+		for _, offset := range offsets {
+			if offset == i {
+				isValidOffset = true
+			}
+		}
+		actual := stuffed.IsStartOfRecord(encoded.Bytes(), i)
+		assert.Equal(t, isValidOffset, actual)
+	}
 }
 
 func TestSortedRecordBuilder(t *testing.T) {

--- a/stuffed/stuffed.go
+++ b/stuffed/stuffed.go
@@ -152,6 +152,21 @@ func FindLastDelimiter(record []byte) int {
 	return bytes.LastIndex(record, []byte{delimiter0, delimiter1})
 }
 
+// IsStartOfRecord returns whether a particular offset within a buffer is the
+// start of a stuffed record.  The offset must either point at the start of the
+// buffer, or immediately after a `0xfe 0xfd` delimiter.  This does not check
+// that the offset points at a valid record, just that it _could_.  (Decode will
+// return an error if it doesn't.)
+func IsStartOfRecord(buffer []byte, offset int) bool {
+	if offset == 1 || offset >= len(buffer) {
+		return false
+	}
+	if offset >= 2 && (buffer[offset-2] != 0xfe || buffer[offset-1] != 0xfd) {
+		return false
+	}
+	return true
+}
+
 // Scanner iterates through a buffer containing zero or more delimited stuffed
 // records.
 type Scanner struct {


### PR DESCRIPTION
This is a new method that does that same thing as `RecordBuilder.Encode`, but also keeps track of the offset of each records in the encoded result.